### PR TITLE
If player is riding a Vehicle, bring the Vehicle as well.

### DIFF
--- a/common/src/main/java/dev/itsmeow/quickhomes/QuickHomesMod.java
+++ b/common/src/main/java/dev/itsmeow/quickhomes/QuickHomesMod.java
@@ -9,6 +9,7 @@ import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
@@ -35,7 +36,12 @@ public class QuickHomesMod {
             ServerPlayer player = command.getSource().getPlayerOrException();
             Pair<Vec3, ResourceKey<Level>> home = ((IStoreHome) player).getHome();
             if(home.getLeft() != null && home.getRight() != null) {
-                player.teleportTo(player.getServer().getLevel(home.getRight()), home.getLeft().x, home.getLeft().y, home.getLeft().z, player.getYRot(), player.getXRot());
+                if (player.isPassenger()) {
+                    Entity vehicle = player.getVehicle();
+                    vehicle.teleportTo(home.getLeft().x, home.getLeft().y, home.getLeft().z);
+                } else {
+                    player.teleportTo(player.getServer().getLevel(home.getRight()), home.getLeft().x, home.getLeft().y, home.getLeft().z, player.getYRot(), player.getXRot());
+                }
                 return 1;
             } else {
                 player.sendMessage(new TextComponent("No home set."), Util.NIL_UUID);

--- a/common/src/main/java/dev/itsmeow/quickhomes/QuickHomesMod.java
+++ b/common/src/main/java/dev/itsmeow/quickhomes/QuickHomesMod.java
@@ -35,7 +35,7 @@ public class QuickHomesMod {
             ServerPlayer player = command.getSource().getPlayerOrException();
             Pair<Vec3, ResourceKey<Level>> home = ((IStoreHome) player).getHome();
             if(home.getLeft() != null && home.getRight() != null) {
-                player.teleportTo(player.getServer().getLevel(home.getRight()), home.getLeft().x, home.getLeft().y, home.getLeft().z, player.yRot, player.xRot);
+                player.teleportTo(player.getServer().getLevel(home.getRight()), home.getLeft().x, home.getLeft().y, home.getLeft().z, player.getYRot(), player.getXRot());
                 return 1;
             } else {
                 player.sendMessage(new TextComponent("No home set."), Util.NIL_UUID);

--- a/common/src/main/resources/quickhomes.mixins.json
+++ b/common/src/main/resources/quickhomes.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "dev.itsmeow.quickhomes.mixin",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_16",
   "minVersion": "0.8",
   "mixins": [
     "ServerPlayerMixin"

--- a/common/src/main/resources/quickhomes.mixins.json
+++ b/common/src/main/resources/quickhomes.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "dev.itsmeow.quickhomes.mixin",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "minVersion": "0.8",
   "mixins": [
     "ServerPlayerMixin"

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 dependencies {
     shadowImplementation "me.zeroeightsix:fiber:${rootProject.fiber_version}"
-    modRuntimeOnly("com.terraformersmc:modmenu:2.0.14") {
+    modRuntimeOnly("com.terraformersmc:modmenu:3.0.1") {
         transitive = false
     }
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 dependencies {
     shadowImplementation "me.zeroeightsix:fiber:${rootProject.fiber_version}"
-    modRuntimeOnly("com.terraformersmc:modmenu:1.16.22") {
+    modRuntimeOnly("com.terraformersmc:modmenu:2.0.14") {
         transitive = false
     }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -17,7 +17,7 @@
     "main": ["dev.itsmeow.quickhomes.QuickHomesModFabric"]
   },
   "depends": {
-    "minecraft": "1.17.1",
+    "minecraft": "1.18.1",
     "fabricloader": ">=0.12.0",
     "fabric": ">=0.32.0"
   },

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -17,7 +17,7 @@
     "main": ["dev.itsmeow.quickhomes.QuickHomesModFabric"]
   },
   "depends": {
-    "minecraft": "1.16.5",
+    "minecraft": "1.17.1",
     "fabricloader": ">=0.12.0",
     "fabric": ">=0.32.0"
   },

--- a/forge/src/main/java/dev/itsmeow/quickhomes/QuickHomesModForge.java
+++ b/forge/src/main/java/dev/itsmeow/quickhomes/QuickHomesModForge.java
@@ -10,7 +10,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import net.minecraftforge.fmllegacy.network.FMLNetworkConstants;
+import net.minecraftforge.network.NetworkConstants;
 import org.apache.commons.lang3.tuple.Pair;
 
 @Mod(QuickHomesMod.MOD_ID)
@@ -21,7 +21,7 @@ public class QuickHomesModForge {
     private static ForgeConfigSpec SERVER_CONFIG_SPEC = null;
 
     public QuickHomesModForge() {
-        ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class, () -> new IExtensionPoint.DisplayTest(() -> FMLNetworkConstants.IGNORESERVERONLY, (s, b) -> true));
+        ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class, () -> new IExtensionPoint.DisplayTest(() -> NetworkConstants.IGNORESERVERONLY, (s, b) -> true));
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::loadComplete);
     }
 

--- a/forge/src/main/java/dev/itsmeow/quickhomes/QuickHomesModForge.java
+++ b/forge/src/main/java/dev/itsmeow/quickhomes/QuickHomesModForge.java
@@ -4,13 +4,13 @@ import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.event.RegisterCommandsEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.ExtensionPoint;
+import net.minecraftforge.fml.IExtensionPoint;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import net.minecraftforge.fml.network.FMLNetworkConstants;
+import net.minecraftforge.fmllegacy.network.FMLNetworkConstants;
 import org.apache.commons.lang3.tuple.Pair;
 
 @Mod(QuickHomesMod.MOD_ID)
@@ -21,7 +21,7 @@ public class QuickHomesModForge {
     private static ForgeConfigSpec SERVER_CONFIG_SPEC = null;
 
     public QuickHomesModForge() {
-        ModLoadingContext.get().registerExtensionPoint(ExtensionPoint.DISPLAYTEST, () -> Pair.of(() -> FMLNetworkConstants.IGNORESERVERONLY, (s, b) -> true));
+        ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class, () -> new IExtensionPoint.DisplayTest(() -> FMLNetworkConstants.IGNORESERVERONLY, (s, b) -> true));
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::loadComplete);
     }
 

--- a/forge/src/main/java/dev/itsmeow/quickhomes/forge/QuickHomesModForge.java
+++ b/forge/src/main/java/dev/itsmeow/quickhomes/forge/QuickHomesModForge.java
@@ -1,5 +1,6 @@
-package dev.itsmeow.quickhomes;
+package dev.itsmeow.quickhomes.forge;
 
+import dev.itsmeow.quickhomes.QuickHomesMod;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.event.RegisterCommandsEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;

--- a/forge/src/main/java/dev/itsmeow/quickhomes/forge/QuickHomesModImpl.java
+++ b/forge/src/main/java/dev/itsmeow/quickhomes/forge/QuickHomesModImpl.java
@@ -1,7 +1,6 @@
 package dev.itsmeow.quickhomes.forge;
 
 import dev.itsmeow.quickhomes.QuickHomesMod;
-import dev.itsmeow.quickhomes.QuickHomesModForge;
 import net.minecraftforge.fml.ModList;
 
 public class QuickHomesModImpl {

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[37,)"
+loaderVersion="[39,)"
 license="MIT"
 issueTrackerURL="https://github.com/itsmeow/QuickHomes/issues"
 displayURL="https://www.curseforge.com/minecraft/mc-mods/quickhomes"
@@ -15,6 +15,6 @@ This mod adds a quick and easy way to set homes with /sethome and /home'''
 [[dependencies.quickhomes]]
     modId="forge"
     mandatory=true
-    versionRange="[37.1.0,)"
+    versionRange="[39.0.0,)"
     ordering="NONE"
     side="SERVER"

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[36,)"
+loaderVersion="[37,)"
 license="MIT"
 issueTrackerURL="https://github.com/itsmeow/QuickHomes/issues"
 displayURL="https://www.curseforge.com/minecraft/mc-mods/quickhomes"
@@ -15,6 +15,6 @@ This mod adds a quick and easy way to set homes with /sethome and /home'''
 [[dependencies.quickhomes]]
     modId="forge"
     mandatory=true
-    versionRange="[36.2.0,)"
+    versionRange="[37.1.0,)"
     ordering="NONE"
     side="SERVER"

--- a/forge/src/main/resources/pack.mcmeta
+++ b/forge/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
     "description": "QuickHomes resources",
-    "pack_format": 6
+    "pack_format": 7
   }
 }

--- a/forge/src/main/resources/pack.mcmeta
+++ b/forge/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
     "description": "QuickHomes resources",
-    "pack_format": 7
+    "pack_format": 8
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,10 @@
     maven_group = dev.itsmeow.quickhomes
 
 # API Versions
-    mc_version = 1.17.1
-    forge_version = 37.1.1
+    mc_version = 1.18.1
+    forge_version = 39.0.10
     fabric_loader_version = 0.12.12
-    fabric_api_version = 0.45.0+1.17
+    fabric_api_version = 0.45.0+1.18
 
 # Publishing
     github = itsmeow/QuickHomes
@@ -15,8 +15,8 @@
     url = https://github.com/itsmeow/QuickHomes
     curse_title = QuickHomes
     curse_project_id = 277625
-    curse_versions_fabric = Minecraft 1.17:1.17.1,Java 16,Fabric
-    curse_versions_forge = Minecraft 1.17:1.17.1,Java 16,Forge
+    curse_versions_fabric = Minecraft 1.18:1.18.1,Java 17,Fabric
+    curse_versions_forge = Minecraft 1.18:1.18.1,Java 17,Forge
 
 # Toolchain Versions
     loom_version = 0.10.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,8 @@
     url = https://github.com/itsmeow/QuickHomes
     curse_title = QuickHomes
     curse_project_id = 277625
-    curse_versions_fabric = Minecraft 1.17:1.17.1,Java 8,Fabric
-    curse_versions_forge = Minecraft 1.17:1.17.1,Java 8,Forge
+    curse_versions_fabric = Minecraft 1.17:1.17.1,Java 16,Fabric
+    curse_versions_forge = Minecraft 1.17:1.17.1,Java 16,Forge
 
 # Toolchain Versions
     loom_version = 0.10.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,10 @@
     maven_group = dev.itsmeow.quickhomes
 
 # API Versions
-    mc_version = 1.16.5
-    forge_version = 36.2.22
+    mc_version = 1.17.1
+    forge_version = 37.1.1
     fabric_loader_version = 0.12.12
-    fabric_api_version = 0.42.0+1.16
+    fabric_api_version = 0.45.0+1.17
 
 # Publishing
     github = itsmeow/QuickHomes
@@ -15,8 +15,8 @@
     url = https://github.com/itsmeow/QuickHomes
     curse_title = QuickHomes
     curse_project_id = 277625
-    curse_versions_fabric = Minecraft 1.16:1.16.5,Java 8,Fabric
-    curse_versions_forge = Minecraft 1.16:1.16.5,Java 8,Forge
+    curse_versions_fabric = Minecraft 1.17:1.17.1,Java 8,Fabric
+    curse_versions_forge = Minecraft 1.17:1.17.1,Java 8,Forge
 
 # Toolchain Versions
     loom_version = 0.10.0-SNAPSHOT


### PR DESCRIPTION
I added the ability for /home to bring the player and anything that it is riding: boats, horses, etc.

I think adding a new config option for bring the Vehicle as well would be good, but wanted to hear your thoughts before I go and implement that.

I tested this on both Forge and Fabric, and Singleplayer and Multiplayer and did not run into any issues.