### PR TITLE
If player is riding a Vehicle, bring the Vehicle as well.

### DIFF
--- a/common/src/main/java/dev/itsmeow/quickhomes/QuickHomesMod.java
+++ b/common/src/main/java/dev/itsmeow/quickhomes/QuickHomesMod.java
@@ -7,6 +7,7 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
@@ -14,6 +15,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import org.apache.commons.lang3.tuple.Pair;
 
+import java.util.List;
 import java.util.function.Predicate;
 
 public class QuickHomesMod {
@@ -37,15 +39,30 @@ public class QuickHomesMod {
             Vec3 homePos = home.getLeft();
             ResourceKey<Level> homeLevel = home.getRight();
             if(homePos != null && homeLevel != null) {
+                ServerLevel serverLevel = player.getServer().getLevel(homeLevel);
+                Entity vehicle = player.getVehicle();
                 if (player.isPassenger()) {
-                    Entity vehicle = player.getVehicle();
-                    // If player is not riding with or on another player, teleport the vehicle along with passengers.
-                    if (!vehicle.getPassengersAndSelf().anyMatch(entity -> (!entity.equals(player)) && entity instanceof Player)) {
-                        vehicle.teleportTo(homePos.x, homePos.y, homePos.z);
+                    if (!serverLevel.equals(player.getLevel())) {
+                        if (hasPlayer(vehicle, player)) {
+                            player.teleportTo(serverLevel, homePos.x, homePos.y, homePos.z, player.getYRot(), player.getXRot());
+                            return 1;
+                        }
+                        List<Entity> passengers = vehicle.getPassengers();
+                        Entity tpVehicle = teleportAcrossDimensions(vehicle, homePos, serverLevel);
+                        for (Entity passenger : passengers) {
+                            Entity tpPassenger = teleportAcrossDimensions(passenger, homePos, serverLevel);
+                            tpVehicle.positionRider(tpPassenger);
+                            tpPassenger.startRiding(tpVehicle);
+                        }
                         return 1;
+                    } else {
+                        if (!hasPlayer(vehicle, player)) {
+                            vehicle.teleportTo(homePos.x, homePos.y, homePos.z);
+                            return 1;
+                        }
                     }
                 }
-                player.teleportTo(player.getServer().getLevel(homeLevel), homePos.x, homePos.y, homePos.z, player.getYRot(), player.getXRot());
+                player.teleportTo(serverLevel, homePos.x, homePos.y, homePos.z, player.getYRot(), player.getXRot());
                 return 1;
             } else {
                 player.sendSystemMessage(Component.literal("No home set."));
@@ -58,6 +75,47 @@ public class QuickHomesMod {
             player.sendSystemMessage(Component.literal("Home set."));
             return 1;
         }));
+    }
+
+    /**
+     * Looks for a player in the passengers and vehicle itself, other than the passed in player.
+     * @param vehicle The vehicle to search through.
+     * @param player The player to not count as a player when one if found.
+     * @return true if another player was found, false otherwise.
+     */
+    private static boolean hasPlayer(Entity vehicle, ServerPlayer player) {
+        return vehicle.getPassengersAndSelf().anyMatch(entity -> (!entity.equals(player)) && entity instanceof Player);
+    }
+
+    /**
+     * Teleport an entity to another dimension.
+     * @param entity The entity to teleport.
+     * @param homePos The position to teleport the entity to.
+     * @param serverLevel The dimension to teleport the entity to.
+     * @return
+     */
+    private static Entity teleportAcrossDimensions(Entity entity, Vec3 homePos, ServerLevel serverLevel) {
+        entity.unRide();
+        // If entity is a player, just call the ServerPlayer tp function that handles cross-dimension already.
+        if (entity instanceof ServerPlayer) {
+            ((ServerPlayer) entity).teleportTo(serverLevel, homePos.x, homePos.y, homePos.z, entity.getYRot(), entity.getXRot());
+            return entity;
+        }
+        // Handle recreating new entity in other dimension.
+        entity.level.getProfiler().popPush("reloading");
+        Entity newEntity = entity.getType().create(serverLevel);
+        if (newEntity != null) {
+            newEntity.restoreFrom(entity);
+            newEntity.moveTo(homePos.x, homePos.y, homePos.z, entity.getYRot(), entity.getXRot());
+            newEntity.setDeltaMovement(entity.getDeltaMovement());
+            serverLevel.addDuringTeleport(newEntity);
+        }
+        // Removing old entity.
+        entity.setRemoved(Entity.RemovalReason.CHANGED_DIMENSION);
+        ((ServerLevel) entity.level).resetEmptyTime();
+        serverLevel.resetEmptyTime();
+
+        return newEntity;
     }
 
     public static void onPlayerJoin(Player player) {


### PR DESCRIPTION
If the player is not riding a vehicle, then there are no changes. If they are, we check to see if the vehicle they are riding is another player or there is a player riding with them. When another player is detected, skip dealing with teleporting the vehicle as well and just teleport the player.